### PR TITLE
Password hash dependency

### DIFF
--- a/app/models/custom/user.js
+++ b/app/models/custom/user.js
@@ -31,7 +31,7 @@ UserSchema.methods.comparePassword = function (candidatePassword, cb) {
   var usrPwd = this.password.split('<||>')
   password.compare(candidatePassword, usrPwd[0], function(err, hash) {
       if (usrPwd[1] === hash) return cb(err)
-      cb(null, isMatch)
+      cb(null, hash)
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "author": "Chris Sevilleja <scotch.io>",
   "license": "MIT",
   "dependencies": {
-    "bcrypt": "^0.8.7",
     "bluebird": "^3.4.6",
     "body-parser": "~1.0.1",
     "express": "~4.0.0",
     "jsonwebtoken": "^7.1.9",
     "mongoose": "*",
     "morgan": "~1.0.0",
-    "require-dir": "^0.3.1"
+    "require-dir": "^0.3.1",
+    "s-salt-pepper": "^2.1.0"
   }
 }


### PR DESCRIPTION
Changing dependency for password hashing method.
There are no reported compatibility issues with this one as there is with bcrypt. (Specialy in AWS Lambda)